### PR TITLE
Fixing /inventory page routing issue on github pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 build
+.history

--- a/src/pages/InventoryPage.jsx
+++ b/src/pages/InventoryPage.jsx
@@ -3,13 +3,14 @@ import DataUploader from "../components/Inventory/DataUploader";
 import IndexNavbar from "../components/Navbars/IndexNavbar";
 
 const InventoryPage = () => {
-  useEffect(() => {
-    if (!window.location.search.includes("refreshed=true")) {
-      const separator = window.location.href.includes('?') ? '&' : '?';
-      window.location.href =
-        window.location.href + separator + "refreshed=true";
-    }
-  }, []);
+  //fix github pages not found error on this page
+  // useEffect(() => {
+  //   if (!window.location.search.includes("refreshed=true")) {
+  //     const separator = window.location.href.includes('?') ? '&' : '?';
+  //     window.location.href =
+  //       window.location.href + separator + "refreshed=true";
+  //   }
+  // }, []);
 
   return (
     <>


### PR DESCRIPTION
While I was doing a deployment, the /inventory page kept breaking, and hence, I looked at the code and found the URL manipulation might be breaking the GitHub pages deployment. It turned out it did. I am unsure if commenting this out alters the business logic, but please consider fixing this issue if this already doesn't.